### PR TITLE
Add support for MediaPipe as a joint detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@
        - Download **yolov3.weights** from [here](https://pjreddie.com/media/files/yolov3.weights),
          place to `./joints_detectors/hrnet/lib/detector/yolo`
      - OpenPose (Not tested, PR to README.md is highly appreciated )
+     - Mediapipe
+       - Install mediapipe from pypi: `pip install mediapipe`
    - **3D Joint detectors**
       - Download **pretrained_h36m_detectron_coco.bin** from [here](https://dl.fbaipublicfiles.com/video-pose-3d/pretrained_h36m_detectron_coco.bin),
         place it into `./checkpoint` folder

--- a/joints_detectors/mediapipe/pose.py
+++ b/joints_detectors/mediapipe/pose.py
@@ -1,0 +1,51 @@
+from tqdm import tqdm
+import mediapipe as mp
+import numpy as np
+import cv2
+
+pose = mp.solutions.pose.Pose(static_image_mode=False, min_detection_confidence=0.5, min_tracking_confidence=0.5)
+
+def generate_kpts(video_file):
+    vid = cv2.VideoCapture(video_file)
+    kpts = []
+    video_length = int(vid.get(cv2.CAP_PROP_FRAME_COUNT))
+
+    for i in tqdm(range(video_length)):
+        ret, frame = vid.read()
+        if not ret:
+            break
+
+        results = pose.process(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
+        if(not results.pose_landmarks):
+            kpts.append(kpts[-1] if len(kpts) > 0 else [[0, 0] for _ in range(17)])
+            continue
+        
+        # Take the coco keypoints
+        l = results.pose_landmarks.landmark
+        pl = mp.solutions.pose.PoseLandmark
+        kpts.append([
+            [l[pl.NOSE].x, l[pl.NOSE].y],
+            [l[pl.LEFT_EYE].x, l[pl.LEFT_EYE].y],
+            [l[pl.RIGHT_EYE].x, l[pl.RIGHT_EYE].y],
+            [l[pl.LEFT_EAR].x, l[pl.LEFT_EAR].y],
+            [l[pl.RIGHT_EAR].x, l[pl.RIGHT_EAR].y],
+            [l[pl.LEFT_SHOULDER].x, l[pl.LEFT_SHOULDER].y],
+            [l[pl.RIGHT_SHOULDER].x, l[pl.RIGHT_SHOULDER].y],
+            [l[pl.LEFT_ELBOW].x, l[pl.LEFT_ELBOW].y],
+            [l[pl.RIGHT_ELBOW].x, l[pl.RIGHT_ELBOW].y],
+            [l[pl.LEFT_WRIST].x, l[pl.LEFT_WRIST].y],
+            [l[pl.RIGHT_WRIST].x, l[pl.RIGHT_WRIST].y],
+            [l[pl.LEFT_HIP].x, l[pl.LEFT_HIP].y],
+            [l[pl.RIGHT_HIP].x, l[pl.RIGHT_HIP].y],
+            [l[pl.LEFT_KNEE].x, l[pl.LEFT_KNEE].y],
+            [l[pl.RIGHT_KNEE].x, l[pl.RIGHT_KNEE].y],
+            [l[pl.LEFT_ANKLE].x, l[pl.LEFT_ANKLE].y],
+            [l[pl.RIGHT_ANKLE].x, l[pl.RIGHT_ANKLE].y]
+        ])
+
+        # multiply all the x coordinates with frame width and y coordinates with frame height.
+        for i in range(len(kpts[-1])):
+            kpts[-1][i][0] *= frame.shape[1]
+            kpts[-1][i][1] *= frame.shape[0]
+
+    return np.array(kpts)

--- a/videopose.py
+++ b/videopose.py
@@ -166,4 +166,4 @@ def inference_video(video_path, detector_2d):
 
 
 if __name__ == '__main__':
-    inference_video('outputs/kunkun_cut.mp4', 'mediapipe_pose')
+    inference_video('outputs/kunkun_cut.mp4', 'alpha_pose')

--- a/videopose.py
+++ b/videopose.py
@@ -38,10 +38,15 @@ def get_detector_2d(detector_name):
     def get_hr_pose():
         from joints_detectors.hrnet.pose_estimation.video import generate_kpts as hr_pose
         return hr_pose
+    
+    def get_mediapipe_pose():
+        from joints_detectors.mediapipe.pose import generate_kpts as mediapipe_pose
+        return mediapipe_pose
 
     detector_map = {
         'alpha_pose': get_alpha_pose,
         'hr_pose': get_hr_pose,
+        'mediapipe_pose': get_mediapipe_pose,
         # 'open_pose': open_pose
     }
 
@@ -61,7 +66,7 @@ class Skeleton:
 def main(args):
     detector_2d = get_detector_2d(args.detector_2d)
 
-    assert detector_2d, 'detector_2d should be in ({alpha, hr, open}_pose)'
+    assert detector_2d, 'detector_2d should be in ({alpha, hr, open, mediapipe}_pose)'
 
     # 2D kpts loads or generate
     if not args.input_npz:
@@ -139,7 +144,7 @@ def main(args):
 def inference_video(video_path, detector_2d):
     """
     Do image -> 2d points -> 3d points to video.
-    :param detector_2d: used 2d joints detector. Can be {alpha_pose, hr_pose}
+    :param detector_2d: used 2d joints detector. Can be {alpha_pose, hr_pose, mediapipe_pose}
     :param video_path: relative to outputs
     :return: None
     """
@@ -161,4 +166,4 @@ def inference_video(video_path, detector_2d):
 
 
 if __name__ == '__main__':
-    inference_video('outputs/kunkun_cut.mp4', 'alpha_pose')
+    inference_video('outputs/kunkun_cut.mp4', 'mediapipe_pose')


### PR DESCRIPTION
Mediapipe is able to provide the same level of keypoint accuracy at around twice the speed on the CPU
Below is a comparison of alpha_pose vs mediapipe_pose in terms of output accuracy

AlphaPose
https://user-images.githubusercontent.com/46800081/210648560-7b98f3cf-92ed-47e8-863c-7f8c97c6dd91.mp4

MediaPipe
https://user-images.githubusercontent.com/46800081/210648651-c707c639-fa76-4428-97ce-c182ad22f297.mp4

